### PR TITLE
Allow Composer to autoload the Paginator class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,5 +14,8 @@
     ],
     "require": {
         "php": ">=5.3.0"
+    },
+    "autoload" {
+        "classmap": ["Paginator.php"]
     }
 }


### PR DESCRIPTION
This adds the autoload.classmap attribute to the composer.json file so Composer can automatically load this class.  Eliminates having to require Paginator.php manually.
