### PR TITLE
Upgraded to support BS3 only

### DIFF
--- a/src/Voodoo/Paginator.php
+++ b/src/Voodoo/Paginator.php
@@ -409,7 +409,7 @@ class Paginator implements IteratorAggregate
         }
         return 
             "
-                <{$wrapTag} class=\"{paginationClsName}\">{$list}</{$wrapTag}>
+                <{$wrapTag} class=\"{$paginationClsName}\">{$list}</{$wrapTag}>
             ";    
     } 
     


### PR DESCRIPTION
I removed the wrapping div tag as that is something that anyone can add themselves in their own templating system. I moved the pagination class to the same element as the wraptag as in BS3 the required markup is:

`<ul class="pagination">
  <li><a href="#">&laquo;</a></li>
  <li><a href="#">1</a></li>
  <li><a href="#">2</a></li>
  <li><a href="#">3</a></li>
  <li><a href="#">4</a></li>
  <li><a href="#">5</a></li>
  <li><a href="#">&raquo;</a></li>
</ul>`
